### PR TITLE
Rebuild jemalloc 5.2.1 b6

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,8 +2,7 @@
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* ./build-aux
 
-set -e
-set -x
+set -exuo pipefail
 
 # Static TLS has caused users to experience some errors of the form
 # "libjemalloc.so.2: cannot allocate memory in static TLS block"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,11 +13,13 @@ source:
 
 build:
   number: 6
+  skip: true  # [win]
   run_exports:
     # Symbols were only removed in update from 3 to 4
     # https://abi-laboratory.pro/index.php?view=timeline&l=jemalloc
     - {{ pin_subpackage(name, max_pin=None) }}
-  skip: true  # [win]
+  missing_dso_whitelist:
+    - "$RPATH/ld64.so.1"  # [s390x]
 
 requirements:
   build:
@@ -25,7 +27,6 @@ requirements:
     - gnuconfig  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - m2-patch  # [win]
     - patch     # [not win]
   host:
 
@@ -43,11 +44,20 @@ test:
     - $CC -I$PREFIX/include -L$PREFIX/lib -ljemalloc test.c
 
 about:
-  home: http://jemalloc.net
+  home: https://jemalloc.net/
   dev_url: https://github.com/jemalloc/jemalloc
+  doc_url: https://jemalloc.net/
   license: BSD-2-Clause
+  license_family: BSD
   license_file: COPYING
   summary: 'general purpose malloc(3) implementation'
+  description: |
+    jjemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support. 
+    jemalloc first came into use as the FreeBSD libc allocator in 2005, and since then it has found its way into numerous applications 
+    that rely on its predictable behavior. In 2010 jemalloc development efforts broadened to include developer support features 
+    such as heap profiling and extensive monitoring/tuning hooks. Modern jemalloc releases continue to be integrated back into FreeBSD, 
+    and therefore versatility remains critical. Ongoing development efforts trend toward making jemalloc among the best allocators 
+    for a broad range of demanding applications, and eliminating/mitigating weaknesses that have practical repercussions for real world applications.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - export-mangled-syms.patch
 
 build:
-  number: 5
+  number: 6
   run_exports:
     # Symbols were only removed in update from 3 to 4
     # https://abi-laboratory.pro/index.php?view=timeline&l=jemalloc


### PR DESCRIPTION
ray_packages requires jemalloc on linux-aarch64 https://github.com/AnacondaRecipes/ray-packages-feedstock/pull/6

Changelog: https://github.com/jemalloc/jemalloc/blob/dev/ChangeLog
License: https://github.com/jemalloc/jemalloc/blob/dev/COPYING
Installation: https://github.com/jemalloc/jemalloc/blob/dev/INSTALL.md


Actions:
1. Update `build.sh`: add `set -exuo pipefail`
2. Bump build number to `1`
3. Add `missing_dso_whitelist: "$RPATH/ld64.so.1"`  for `s390x`
4. Remove `m2-patch  # [win]`
5. Fix `home` url
6. Add `doc_url`
7. Add `description`
8. Add `license_family`