### PR TITLE
PKG-14081: split jemalloc/jemalloc-local upstream_sources for DDB

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -8,4 +8,11 @@ upstream_sources:
       to_pattern: \1
     packages:
       - jemalloc
+  - github:
+      identifier: jemalloc/jemalloc
+      use_max_tag: true
+      exclude_regex: (?i)^(?=.*(?:(?<=\d)rc\d*|(?<=\d)dev\d+|(?:^|[-._])(?:alpha|beta|gamma|pre|preview)(?:\d+)?|[-._]rc\d+|(?:^|[-._])dev\d+|(?:\d+\.)+\d+[ab]\d*)).+$
+      from_pattern: ^v?(\d+(?:\.\d+)*.*)$
+      to_pattern: \1
+    packages:
       - jemalloc-local


### PR DESCRIPTION
## Summary
PKG-14081 — duplicate `github` upstream_source using the same `jemalloc/jemalloc` identifier so `jemalloc-local` has an explicit upstream block (fixes missing URL / mapping for the secondary output).

## Ticket
PKG-14081

Made with [Cursor](https://cursor.com)